### PR TITLE
fix: Use hard-coded API URL for blog OG images.

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -30,10 +30,12 @@ function Layout({
     useOgTemplate = false,
     children,
 }: LayoutProps) {
-    const { url, origin } = useCurrentUrl();
+    const { url } = useCurrentUrl();
 
     const ogImagePath = useOgTemplate
-        ? `${origin}/api/og?text=${encodeURIComponent(removeEmojis(title))}`
+        ? `https://www.zachsnoek.com/api/og?text=${encodeURIComponent(
+              removeEmojis(title)
+          )}`
         : `${url}/images/og-default.png`;
 
     return (


### PR DESCRIPTION
This is because `blog.zachsnoek.com` forwards to `zachsnoek.com`, so the OG image for `blog.zachsnoek.com` would be `zachsnoek.com/blog/api/...`.